### PR TITLE
Fix candlestick series error in trading chart

### DIFF
--- a/src/components/TradingChart.tsx
+++ b/src/components/TradingChart.tsx
@@ -34,8 +34,9 @@ export const TradingChart = ({ data }: { data: ChartData[] }) => {
         // Store the new chart instance
         chartInstanceRef.current = chart;
 
-        // Add candlestick series
-        const candlestickSeries = chart.addCandlestickSeries({
+        // Add candlestick series using the new v5 API
+        const candlestickSeries = chart.addSeries({
+            type: 'Candlestick',
             upColor: '#26a69a',
             downColor: '#ef5350',
             borderDownColor: '#ef5350',


### PR DESCRIPTION
Update TradingChart to use `chart.addSeries({ type: 'Candlestick' })` to fix a `TypeError` caused by a `lightweight-charts` v5 API change.

---
<a href="https://cursor.com/background-agent?bcId=bc-aef1d62d-a73e-42f6-8788-0474396e4be0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aef1d62d-a73e-42f6-8788-0474396e4be0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

